### PR TITLE
Add CHMS metadata schemas for variables and variable_details

### DIFF
--- a/inst/metadata/README.md
+++ b/inst/metadata/README.md
@@ -1,0 +1,338 @@
+# Metadata Documentation for chmsflow
+
+**Last updated**: 2025-10-18
+
+This directory contains metadata schema documentation and database configuration files for the chmsflow package. These files document the structure, validation rules, and patterns used in CHMS data harmonization.
+
+## Purpose
+
+These YAML files serve multiple purposes:
+
+1. **Documentation**: Define the structure and meaning of metadata fields
+2. **Validation**: Provide rules for automated quality checking
+3. **Future migration**: Support eventual transition to recodeflow architecture
+4. **Consistency**: Ensure alignment with cchsflow and broader recodeflow ecosystem
+
+## Directory Structure
+
+```
+inst/metadata/
+├── README.md                          # This file
+├── documentation/                     # General metadata standards
+│   ├── database_metadata.yaml        # Dublin Core database-level metadata schema
+│   └── metadata_registry.yaml        # Central registry of shared specifications
+└── schemas/                           # Data structure schemas
+    └── chms/                          # CHMS-specific schemas
+        ├── chms_database_config.yaml # CHMS database selection and parsing rules
+        ├── variables.yaml            # Schema for variables.csv
+        └── variable_details.yaml     # Schema for variable-details.csv
+```
+
+## Key Files
+
+### documentation/database_metadata.yaml
+
+Defines Dublin Core-compliant database-level metadata:
+- Dataset titles, descriptions, creators
+- Coverage (temporal, spatial, population)
+- Rights and access information
+- Keywords and subject classification
+
+**Use case**: When creating comprehensive dataset documentation
+
+### documentation/metadata_registry.yaml
+
+Central registry of shared specifications used across all schema files:
+- CSV format specifications
+- Tier system (core, optional, versioning, extension)
+- Validation patterns (variable names, dates, etc.)
+- Transformation patterns for variableStart field
+
+**Use case**: Reference for understanding validation rules and patterns
+
+### schemas/chms/variables.yaml
+
+Schema for `inst/extdata/variables.csv`:
+- Field definitions (variable, label, variableType, databaseStart, variableStart)
+- Validation rules and constraints
+- Examples and usage notes
+- Tier classification (core vs optional fields)
+
+**Use case**: Understanding what each column in variables.csv means
+
+### schemas/chms/variable_details.yaml
+
+Schema for `inst/extdata/variable-details.csv`:
+- Field definitions (variable, cycle, recodes, catLabel)
+- Recoding specifications
+- Missing data handling
+- Category label requirements
+
+**Use case**: Understanding how to specify variable recoding rules
+
+### schemas/chms/chms_database_config.yaml
+
+**CHMS database configuration following recodeflow conventions**:
+
+**Recodeflow conventions** (work across CCHS, CHMS, all projects):
+- variableStart format specifications (support rec_with_table()):
+  - `[varname]` - bracket format (database-agnostic)
+  - `database::varname` - database-prefixed format
+  - `database::var1, [var2]` - mixed format
+  - `DerivedVar::[var1, var2]` - derived variables
+- Range notation patterns (e.g., `[7,9]`, `[18.5,25)`, `else`)
+- tagged_na patterns for missing data
+
+**CHMS-specific elements**:
+- Valid cycle names (cycle1-7, cycle1_meds-cycle6_meds)
+- Cycle naming patterns and validation
+- OBSERVATION: Cycle 1 often has different variable names than Cycles 2-6
+  (e.g., amsdmva1 vs ammdmva1) - this is a CHMS data pattern
+
+**Use case**: Understanding which patterns are universal recodeflow conventions vs CHMS-specific observations
+
+## Recodeflow Conventions Applied to CHMS
+
+### Important: Recodeflow vs CHMS-Specific
+
+**Recodeflow conventions** (universal across all harmonization projects):
+- variableStart formats: `[varname]`, `database::varname`, mixed, DerivedVar
+- Range notation: `[7,9]`, `[18.5,25)`, `else`
+- tagged_na patterns for missing data
+- These support rec_with_table() and recodeflow functions
+
+**CHMS-specific observations**:
+- Cycle naming: cycle1, cycle2, cycle1_meds, etc.
+- Pattern: Cycle 1 (2007-2009) often used different variable names than later cycles
+
+### variableStart Formats (RECODEFLOW CONVENTION)
+
+The `variableStart` field supports multiple recodeflow-standard formats:
+
+#### 1. Bracket format `[varname]` - RECODEFLOW CONVENTION
+```yaml
+variable: clc_age
+variableStart: [clc_age]
+databaseStart: cycle1, cycle2, cycle3, cycle4, cycle5, cycle6
+```
+**Recodeflow standard**: Used when variable name is **consistent across all databases/cycles**.
+Works in CCHS, CHMS, and all recodeflow projects.
+
+#### 2. Database-prefixed format `database::varname` - RECODEFLOW CONVENTION
+```yaml
+variable: gen_025
+variableStart: cycle1::gen_15, cycle2::gen_15, cycle3::gen_15, cycle4::gen_15, [gen_025]
+databaseStart: cycle1, cycle2, cycle3, cycle4, cycle5, cycle6
+```
+**Recodeflow standard**: Format is `database_name::variable_name`
+- In CHMS: database = cycle1, cycle2, etc.
+- In CCHS: database = cchs2001, cchs2017_p, etc.
+
+Used when variable name **changes across databases/cycles**.
+
+#### 3. Mixed format `database::var1, [var2]` - RECODEFLOW CONVENTION
+```yaml
+variable: ammdmva1
+variableStart: cycle1::amsdmva1, [ammdmva1]
+databaseStart: cycle1, cycle2, cycle3, cycle4, cycle5, cycle6
+```
+**Recodeflow standard**: `[variable]` represents the **DEFAULT** for all databases not specifically referenced.
+
+Format: `database::specific_name, [default_name]`
+- For specified database: use `database::specific_name`
+- For all other databases: use `[default_name]` as default
+
+**Design rationale**: Reduces verbosity and repetition when only one or a few databases use different variable names.
+
+**CHMS example**: Instead of writing:
+```
+cycle1::amsdmva1, cycle2::ammdmva1, cycle3::ammdmva1, cycle4::ammdmva1, cycle5::ammdmva1, cycle6::ammdmva1
+```
+
+We write:
+```
+cycle1::amsdmva1, [ammdmva1]
+```
+
+Where `[ammdmva1]` is the default for cycles 2-6.
+
+#### 4. DerivedVar format `DerivedVar::[var1, var2, ...]` - RECODEFLOW CONVENTION
+```yaml
+variable: adj_hh_inc
+variableStart: DerivedVar::[thi_01, dhhdsz]
+databaseStart: cycle1, cycle2, cycle3, cycle4, cycle5, cycle6
+```
+**Recodeflow standard**: Used for variables requiring **calculation from multiple sources**.
+Supported by rec_with_table() across all recodeflow projects.
+
+MockData functions currently return NULL for DerivedVar (future enhancement).
+
+### Range Notation (RECODEFLOW CONVENTION)
+
+The `recodes` field in variable-details.csv uses **recodeflow-standard range notation**:
+
+```yaml
+# Integer ranges
+[7,9]         # Includes 7, 8, 9
+[1,5)         # Includes 1, 2, 3, 4 (excludes 5)
+
+# Continuous ranges
+[18.5,25)     # BMI: 18.5 ≤ x < 25
+[25,30)       # BMI: 25 ≤ x < 30
+
+# Special values
+else          # Catch-all for values not covered by other rules
+```
+
+This notation is **universal across all recodeflow projects** (CCHS, CHMS, etc.) and
+is parsed by `parse_range_notation()` function (also used in cchsflow).
+
+### databaseStart Format
+
+Comma-separated list of valid database/cycle names:
+
+```yaml
+# Single cycle
+databaseStart: cycle1
+
+# Multiple cycles
+databaseStart: cycle1, cycle2, cycle3, cycle4, cycle5, cycle6
+
+# Medication cycles
+databaseStart: cycle1_meds, cycle2_meds, cycle3_meds
+```
+
+**Validation rules**:
+- All cycle names must be valid (see `chms_database_config.yaml`)
+- Use exact matching (not substring matching)
+- Spaces after commas are optional but recommended
+- No mixing regular and _meds cycles
+
+## How Parsers Use These Schemas
+
+### parse_variable_start.R
+
+Uses the patterns documented in `chms_database_config.yaml`:
+
+1. **Strategy 1**: Look for `cycle::varname` matching requested cycle
+2. **Strategy 2**: Check if entire string is `[varname]` format
+3. **Strategy 2b**: Check if any segment is `[varname]` (mixed format fallback)
+4. **Strategy 3**: Use plain text as-is
+5. **Return NULL**: For DerivedVar format
+
+Example with mixed format:
+```r
+# metadata: variableStart: "cycle1::amsdmva1, [ammdmva1]"
+
+parse_variable_start("cycle1::amsdmva1, [ammdmva1]", "cycle1")
+# Returns: "amsdmva1" (Strategy 1 matches)
+
+parse_variable_start("cycle1::amsdmva1, [ammdmva1]", "cycle2")
+# Returns: "ammdmva1" (Strategy 2b uses bracket segment as fallback)
+```
+
+### get_cycle_variables.R
+
+Uses `databaseStart` validation rules:
+
+```r
+# Split databaseStart by comma and exact match
+cycles <- strsplit(db_start, ",")[[1]]
+cycles <- trimws(cycles)
+cycle %in% cycles  # Exact match, not substring
+```
+
+This prevents `cycle1` from matching `cycle1_meds`.
+
+## Validation
+
+Run automated validation with:
+
+```r
+source("data-raw/validate-metadata.R")
+```
+
+This checks:
+- ✓ All databaseStart cycles are valid
+- ✓ All variableStart entries parse correctly
+- ✓ Categorical variables have variable_details
+- ⚠ Parsed names are reasonable (warnings only)
+
+## Relationship to cchsflow and recodeflow
+
+These schema files document **recodeflow conventions** that work across all projects:
+
+**From cchsflow (recodeflow standards)**:
+- `documentation/database_metadata.yaml` - Dublin Core standard (recodeflow)
+- `documentation/metadata_registry.yaml` - Shared specifications (recodeflow)
+- `schemas/chms/variables.yaml` - Core variable schema (recodeflow)
+- `schemas/chms/variable_details.yaml` - Variable details schema (recodeflow)
+
+**CHMS-specific configuration**:
+- `schemas/chms/chms_database_config.yaml` - CHMS cycle names and observed patterns
+
+**Key distinction**:
+- **Recodeflow conventions**: variableStart formats, range notation, tagged_na - work across CCHS, CHMS, all projects
+- **CHMS-specific**: Cycle naming (cycle1, cycle2), the *observation* that Cycle 1 often has different names
+
+This ensures we're using standard recodeflow patterns while documenting CHMS-specific observations.
+
+## Future Migration to recodeflow
+
+When chmsflow migrates to the recodeflow architecture:
+
+1. These schemas define the expected structure
+2. CSV files in `inst/extdata/` can be validated against schemas
+3. Migration scripts can reference field definitions
+4. Parsing logic is already documented for reuse
+
+## Common Questions
+
+### Why mixed format (`database::var1, [var2]`)?
+
+**Recodeflow convention**: The `[variable]` notation represents the **DEFAULT** for all databases that aren't specifically referenced. The `database::variable` notation is the **exception/override**.
+
+**Purpose**: Reduces verbosity and repetition in metadata. Instead of repeating the same variable name for multiple databases, you specify the exception(s) and provide a default.
+
+**CHMS example**: Cycle 1 (2007-2009) often used different variable names than Cycles 2-6. Rather than:
+```
+cycle1::amsdmva1, cycle2::ammdmva1, cycle3::ammdmva1, cycle4::ammdmva1, cycle5::ammdmva1, cycle6::ammdmva1
+```
+
+We write:
+```
+cycle1::amsdmva1, [ammdmva1]
+```
+
+This design choice reduces repetition while preserving traceability.
+
+### Why are DerivedVar variables NULL in MockData?
+
+DerivedVar is a **recodeflow convention** for variables requiring custom calculation logic (e.g., `adj_hh_inc` = `thi_01 / dhhdsz`).
+
+The MockData functions focus on simple mapping from metadata specifications. Derived variables would require implementing the calculation logic. This is a future enhancement for MockData, though rec_with_table() in recodeflow already supports DerivedVar.
+
+### How do I know if my metadata is valid?
+
+Run `Rscript data-raw/validate-metadata.R` to check:
+- All cycles in databaseStart are valid
+- All variableStart entries parse for declared cycles
+- All categorical variables have specifications
+- No case-sensitivity issues
+
+## References
+
+- **cchsflow metadata**: `/Users/dmanuel/github/cchsflow/inst/metadata/`
+- **Dublin Core standard**: https://www.dublincore.org/specifications/dublin-core/
+- **DCAT vocabulary**: https://www.w3.org/TR/vocab-dcat-2/
+- **recodeflow architecture**: (in development)
+
+## Maintenance
+
+These schema files should be updated when:
+- New cycles are added (update `valid_cycles` in chms_database_config.yaml)
+- New variableStart patterns are introduced
+- Field definitions change in variables.csv or variable-details.csv
+- Migration to recodeflow requires new specifications
+
+**Maintainer**: chmsflow development team

--- a/inst/metadata/README.md
+++ b/inst/metadata/README.md
@@ -244,20 +244,6 @@ cycle %in% cycles  # Exact match, not substring
 
 This prevents `cycle1` from matching `cycle1_meds`.
 
-## Validation
-
-Run automated validation with:
-
-```r
-source("data-raw/validate-metadata.R")
-```
-
-This checks:
-- ✓ All databaseStart cycles are valid
-- ✓ All variableStart entries parse correctly
-- ✓ Categorical variables have variable_details
-- ⚠ Parsed names are reasonable (warnings only)
-
 ## Relationship to cchsflow and recodeflow
 
 These schema files document **recodeflow conventions** that work across all projects:
@@ -311,14 +297,6 @@ This design choice reduces repetition while preserving traceability.
 DerivedVar is a **recodeflow convention** for variables requiring custom calculation logic (e.g., `adj_hh_inc` = `thi_01 / dhhdsz`).
 
 The MockData functions focus on simple mapping from metadata specifications. Derived variables would require implementing the calculation logic. This is a future enhancement for MockData, though rec_with_table() in recodeflow already supports DerivedVar.
-
-### How do I know if my metadata is valid?
-
-Run `Rscript data-raw/validate-metadata.R` to check:
-- All cycles in databaseStart are valid
-- All variableStart entries parse for declared cycles
-- All categorical variables have specifications
-- No case-sensitivity issues
 
 ## References
 

--- a/inst/metadata/documentation/database_metadata.yaml
+++ b/inst/metadata/documentation/database_metadata.yaml
@@ -1,0 +1,266 @@
+schema_version: "1.0.0"
+schema_date: "2025-06-22"
+description: "Database metadata schema for recodeflow - defines Dublin Core compliant dataset-level metadata for databases and data collections."
+registry_file: "metadata_registry.yaml"
+
+# Note: YAML format specifications are defined in metadata_registry.yaml to maintain DRY principles
+
+database_metadata_schema:
+  title: "Database metadata configuration"
+  description: "Defines dataset-level metadata following Dublin Core standards for database documentation and cataloging."
+  
+  standard: "Dublin Core with DCAT extensions"
+  target_format: "YAML metadata files"
+  
+  # Field definitions following Dublin Core standard
+  fields:
+    # ============================================================================
+    # CORE DUBLIN CORE FIELDS - Essential dataset documentation
+    # ============================================================================
+    
+    - name: "title"
+      title: "Dataset title"
+      description: "Name of the dataset."
+      type: "string"
+      tier: "core"
+      dublin_core_element: "dc:title"
+      constraints:
+        required: true
+      notes: |
+        Provide a clear, concise name for the dataset.
+        Examples: "Health Survey 2024", "Primary Biliary Cirrhosis (PBC) Data Set"
+        
+    - name: "description"
+      title: "Dataset description"
+      description: "Detailed explanation of the dataset."
+      type: "string"
+      tier: "core"
+      dublin_core_element: "dc:description"
+      constraints:
+        required: true
+      notes: |
+        Comprehensive description of the dataset including purpose, scope, and methodology.
+        Should be sufficient for users to understand if the dataset meets their needs.
+        
+    - name: "creator"
+      title: "Dataset creator"
+      description: "Person or organization responsible for creating the data."
+      type: "array"
+      tier: "core"
+      dublin_core_element: "dc:creator"
+      constraints:
+        required: true
+      item_structure:
+        name: "Creator name"
+        affiliation: "Creator affiliation (optional)"
+        orcid: "ORCID identifier (optional)"
+      notes: |
+        Attribution of data origin and responsibility.
+        Examples: "Mayo Clinic", "RecodeFlow Team", "Statistics Canada"
+        
+    - name: "publisher"
+      title: "Dataset publisher"
+      description: "Organization publishing the data."
+      type: "string"
+      tier: "core"
+      dublin_core_element: "dc:publisher"
+      constraints:
+        required: true
+      notes: |
+        Identifies the official data publisher or distributing organization.
+        Examples: "Public Health Agency", "Mayo Clinic", "CRAN"
+        
+    - name: "subject"
+      title: "Dataset subject"
+      description: "Topics covered by the dataset."
+      type: "array"
+      tier: "core"
+      dublin_core_element: "dc:subject"
+      constraints:
+        required: true
+      notes: |
+        Categorize dataset's thematic content using relevant keywords or controlled vocabularies.
+        Examples: ["primary biliary cirrhosis", "clinical study", "medical research"]
+        
+    - name: "date_created"
+      title: "Creation date"
+      description: "Dataset creation date."
+      type: "string"
+      tier: "core"
+      dublin_core_element: "dc:date"
+      format: "date"
+      constraints:
+        required: true
+        pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      notes: |
+        Use ISO date format: YYYY-MM-DD
+        Track dataset's initial creation date.
+        
+    - name: "date_modified"
+      title: "Last modification date"
+      description: "Date when dataset was last modified."
+      type: "string"
+      tier: "optional"
+      dublin_core_element: "dcterms:modified"
+      format: "date"
+      constraints:
+        pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      notes: |
+        Use ISO date format: YYYY-MM-DD
+        Track most recent updates to the dataset.
+        
+    - name: "version"
+      title: "Dataset version"
+      description: "Version number of the dataset."
+      type: "string"
+      tier: "optional"
+      dublin_core_element: "dcterms:hasVersion"
+      constraints:
+        pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+      notes: |
+        Track dataset iterations using semantic versioning (e.g., 1.0.0).
+        Increment for changes: major.minor.patch
+        
+    - name: "license"
+      title: "Licensing information"
+      description: "Licensing and usage rights information."
+      type: "string"
+      tier: "core"
+      dublin_core_element: "dc:rights"
+      constraints:
+        required: true
+      notes: |
+        Specify usage and distribution rights clearly.
+        Examples: "CC-BY 4.0", "Open Source", "Restricted - Contact Publisher"
+        
+    - name: "contact_point"
+      title: "Dataset contact"
+      description: "Contact information for dataset inquiries."
+      type: "string"
+      tier: "core"
+      dublin_core_element: "dcat:contactPoint"
+      constraints:
+        required: true
+      notes: |
+        Provide communication channel for questions about the dataset.
+        Examples: "support@example.org", "researcher@institution.edu"
+
+    # ============================================================================
+    # EXTENDED DUBLIN CORE / DCAT FIELDS - Enhanced metadata
+    # ============================================================================
+    
+    - name: "type"
+      title: "Dataset type"
+      description: "Type or nature of the dataset."
+      type: "string"
+      tier: "optional"
+      dublin_core_element: "dc:type"
+      constraints:
+        enum: ["Dataset", "Survey", "Clinical Trial", "Administrative Data", "Registry"]
+      notes: |
+        Classify the nature of the data collection.
+        
+    - name: "format"
+      title: "Dataset format"
+      description: "Physical or digital manifestation of the dataset."
+      type: "string"
+      tier: "optional"
+      dublin_core_element: "dc:format"
+      notes: |
+        Describe the format and structure of the data.
+        Examples: "Tabular data", "CSV files", "R data frames"
+        
+    - name: "identifier"
+      title: "Dataset identifier"
+      description: "Unique identifier for the dataset."
+      type: "array"
+      tier: "optional"
+      dublin_core_element: "dc:identifier"
+      item_structure:
+        type: "Identifier type"
+        value: "Identifier value"
+      notes: |
+        Provide unique identifiers for referencing the dataset.
+        Examples: DOI, package name, institutional ID
+        
+    - name: "source"
+      title: "Dataset source"
+      description: "Source or origin of the dataset."
+      type: "string"
+      tier: "optional"
+      dublin_core_element: "dc:source"
+      notes: |
+        Reference to the original source or related datasets.
+        Examples: URLs, publications, parent datasets
+        
+    - name: "language"
+      title: "Dataset language"
+      description: "Language(s) used in the dataset."
+      type: "string"
+      tier: "optional"
+      dublin_core_element: "dc:language"
+      constraints:
+        pattern: "^[a-z]{2}(-[A-Z]{2})?$"
+      notes: |
+        Use ISO 639-1 language codes (e.g., "en", "fr", "en-CA").
+        
+    - name: "relation"
+      title: "Related resources"
+      description: "Relationships to other datasets or resources."
+      type: "array"
+      tier: "optional"
+      dublin_core_element: "dc:relation"
+      item_structure:
+        type: "Relationship type"
+        identifier: "Related resource identifier"
+        description: "Description of relationship"
+      notes: |
+        Document connections to related datasets, publications, or projects.
+        
+    - name: "coverage"
+      title: "Dataset coverage"
+      description: "Spatial or temporal coverage of the dataset."
+      type: "object"
+      tier: "optional"
+      dublin_core_element: "dc:coverage"
+      structure:
+        spatial: "Geographic coverage"
+        temporal: "Time period coverage"
+      notes: |
+        Specify the scope of data collection in space and time.
+
+    # ============================================================================
+    # RECODEFLOW-SPECIFIC EXTENSIONS - Integration metadata
+    # ============================================================================
+    
+    - name: "recodeflow_integration"
+      title: "Recodeflow integration metadata"
+      description: "Metadata specific to recodeflow usage and integration."
+      type: "object"
+      tier: "extension"
+      structure:
+        variables_file: "Associated variables.csv file"
+        variable_details_file: "Associated variable_details.csv file"
+        harmonization_notes: "Notes about harmonization approach"
+        rec_with_table_compatible: "Boolean indicating compatibility"
+      notes: |
+        Integration metadata for recodeflow workflow compatibility.
+        Links database metadata to associated variable definition files.
+  
+  # Usage patterns
+  usage_patterns:
+    metadata_files:
+      description: "YAML files alongside data files for metadata documentation."
+      naming_convention: "{dataset_name}_metadata.yaml"
+      examples: ["pbc_metadata.yaml", "cchs2017_metadata.yaml"]
+
+  # Validation and quality
+  validation_notes: |
+    - All required Dublin Core fields must be present
+    - Date fields must follow ISO 8601 format (YYYY-MM-DD)
+    - Language codes must follow ISO 639-1 standard
+    - Contact points should be valid email addresses or URLs
+    - Version numbers should follow semantic versioning when provided
+    
+  # Note: Missing data handling, validation modes, and shared specifications
+  # are defined in metadata_registry.yaml

--- a/inst/metadata/documentation/metadata_registry.yaml
+++ b/inst/metadata/documentation/metadata_registry.yaml
@@ -1,0 +1,212 @@
+schema_version: "1.0.0"
+schema_date: "2025-06-22"
+description: "Central registry for recodeflow metadata schemas and shared specifications."
+purpose: "Single source of truth for shared specifications used across variables.yaml and variable_details.yaml schemas."
+
+# ============================================================================
+# SHARED SPECIFICATIONS - DRY compliance
+# ============================================================================
+
+shared_specifications:
+  csv_format:
+    description: "Standard CSV formatting rules used across all recodeflow metadata files."
+    encoding: "UTF-8"
+    bom: false
+    delimiter: ","
+    quote_char: '"'
+    escape_char: '"'
+    line_terminator: "\n"
+    header_required: true
+    header_case_sensitive: true
+    quote_when_needed: true
+    trailing_delimiter: false
+    blank_lines: "skip"
+    comment_char: null
+    
+  validation_patterns:
+    description: "Common regex patterns and validation rules used across schemas."
+    patterns:
+      variable_name: "^[a-zA-Z_][a-zA-Z0-9_]*$"
+      semantic_version: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+      iso_date: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      
+    # variableStart transformation patterns (used in both schemas)
+    transformation_patterns:
+      simple_reference:
+        pattern: "^\\[[a-zA-Z][a-zA-Z0-9_]*\\]$"
+        description: "References variable from default/any source database (case-insensitive)."
+        example: "[ADL_005] or [adl_005]"
+        
+      database_mapping:
+        pattern: "^[a-zA-Z0-9_]+::[a-zA-Z][a-zA-Z0-9_]*$"
+        description: "Explicit database::variable mapping for single source (case-insensitive)."
+        example: "cchs2001_p::RACA_6A or cchs2001_p::raca_6a"
+        
+      derived_variable:
+        pattern: "^DerivedVar::\\[([a-zA-Z][a-zA-Z0-9_]*(,\\s*[a-zA-Z][a-zA-Z0-9_]*)*)\\]$"
+        description: "Computed variable from multiple inputs using derivation function."
+        example: "DerivedVar::[PAC_4A_cont, PAC_4B_cont]"
+        
+      multiple_database_mapping:
+        pattern: "^[a-zA-Z0-9_]+::[a-zA-Z][a-zA-Z0-9_]*(,\\s*[a-zA-Z0-9_]+::[a-zA-Z][a-zA-Z0-9_]*)*$"
+        description: "Variable exists in multiple databases with different names (case-insensitive)."
+        example: "cchs2001_p::RACA_6A, cchs2003_p::RACC_6A"
+        
+      mixed_pattern:
+        pattern: "^(\\[[a-zA-Z][a-zA-Z0-9_]*\\]|[a-zA-Z0-9_]+::[a-zA-Z][a-zA-Z0-9_]*|DerivedVar::\\[[a-zA-Z][a-zA-Z0-9_]+(,\\s*[a-zA-Z][a-zA-Z0-9_]*)*\\])(,\\s*(\\[[a-zA-Z][a-zA-Z0-9_]*\\]|[a-zA-Z0-9_]+::[a-zA-Z][a-zA-Z0-9_]*|DerivedVar::\\[[a-zA-Z][a-zA-Z0-9_]+(,\\s*[a-zA-Z][a-zA-Z0-9_]*)*\\]))*$"
+        description: "Complex patterns combining multiple transformation types (case-insensitive)."
+        example: "cchs2001_p::RACA_6A, cchs2003_p::RACC_6A, [ADL_01]"
+        
+    # recStart interval notation patterns
+    interval_notation:
+      simple_values:
+        pattern: "^[a-zA-Z0-9]+$"
+        description: "Single values (text or numeric)."
+        examples: ["1", "english", "male"]
+        
+      closed_intervals:
+        pattern: "^\\[[0-9]*\\.?[0-9]*,\\s*[0-9]*\\.?[0-9]*\\]$"
+        description: "Closed intervals [a,b] - includes both endpoints."
+        examples: ["[1,3]", "[18.5,24.9]"]
+        
+      open_intervals:
+        pattern: "^\\([0-9]*\\.?[0-9]*,\\s*[0-9]*\\.?[0-9]*\\)$"
+        description: "Open intervals (a,b) - excludes both endpoints."
+        examples: ["(0,18.5)", "(65,120)"]
+        
+      half_open_intervals:
+        pattern: "^[\\[\\(][0-9]*\\.?[0-9]*,\\s*[0-9]*\\.?[0-9]*[\\]\\)]$"
+        description: "Half-open intervals [a,b) or (a,b]."
+        examples: ["[25,30)", "(18.5,25]"]
+        
+      complex_decimal_intervals:
+        pattern: "^\\[[-]?[0-9]*\\.?[0-9]*,\\s*[-]?[0-9]*\\.?[0-9]*[\\)\\]]$"
+        description: "Advanced intervals with negative decimals (Health Utility Index, complex scores)."
+        examples: ["[-0.359,1]", "[0.0487,0.1846)", "[-0.2231,-0.0872)"]
+        
+    # dummyVariable naming patterns
+    dummy_variable_patterns:
+      recommended_pattern: "^[a-zA-Z0-9_]+_(cat|cont)[0-9]+(_[0-9]+|_NA::[a-z])?$"
+      description: "Systematic naming for generated variables providing natural grouping."
+      examples:
+        categorical: ["age_cat4_1", "age_cat4_2", "smoking_cat3_1"]
+        continuous: ["bmi_cont1", "height_cont1"]
+      benefits: "Provides natural grouping and stable ordering for CSV files and git diffs."
+      
+  missing_data_standards:
+    description: "Standardized missing data handling across recodeflow system."
+    csv_metadata_fields: ["", "NA", "N/A"]
+    r_compliant_values: ["NA::a", "NA::b", "NA::c", "NA::d"]
+    usage_guidelines: |
+      - Use empty strings, "NA", or "N/A" for missing metadata fields
+      - Use tagged missing values (NA::a, etc.) for survey data patterns
+      
+  tier_system:
+    description: "Standard tier classification system used across schemas."
+    philosophy: "Users specify tier, system handles complexity."
+    tiers:
+      core:
+        description: "Essential fields required for basic functionality."
+        presence: "required"
+        validation_strictness: "strict"
+        
+      optional:
+        description: "Extensions for enhanced documentation and organization."
+        presence: "recommended"
+        validation_strictness: "permissive"
+        
+      extension:
+        description: "Enhanced functionality fields for advanced features."
+        presence: "conditional"
+        validation_strictness: "permissive"
+        
+      versioning:
+        description: "Best practices for project management, transparency, and reproducibility."
+        presence: "recommended"
+        validation_strictness: "permissive"
+
+# ============================================================================
+# SCHEMA REGISTRY - Current implementation
+# ============================================================================
+
+schema_registry:
+  # Schema file locations within package structure
+  schema_locations:
+    base_path: "inst/metadata"
+    core_schemas_path: "inst/metadata/schemas/core"
+    documentation_path: "inst/metadata/documentation"
+    
+  harmonization_schemas:
+    variables:
+      file: "variables.yaml"
+      full_path: "inst/metadata/schemas/core/variables.yaml"
+      purpose: "Define harmonized variable attributes, types, labels, and specifications."
+      target_csv: "variables.csv"
+      
+    variable_details:
+      file: "variable_details.yaml"
+      full_path: "inst/metadata/schemas/core/variable_details.yaml"
+      purpose: "Define value-level transformations, recoding logic, and categorical mappings."
+      target_csv: "variable_details.csv"
+      
+  supporting_schemas:
+    metadata_registry:
+      file: "metadata_registry.yaml"
+      full_path: "inst/metadata/documentation/metadata_registry.yaml"
+      purpose: "Central registry for shared specifications and schema definitions."
+      
+    database_metadata:
+      file: "database_metadata.yaml" 
+      full_path: "inst/metadata/documentation/database_metadata.yaml"
+      purpose: "Database-specific metadata and configuration."
+      
+  cross_validation_requirements:
+    variable_consistency: "variable_details.variable must exist in variables.variable"
+    database_consistency: "databaseStart values must match between schemas"
+    template_consistency: "templateVariable references must be valid"
+
+# ============================================================================
+# EXTENSION REGISTRY - Current extensions
+# ============================================================================
+
+extension_registry:
+  template_variables:
+    description: "Reusable transformation patterns to avoid categorical structure duplication."
+    affects_schemas: ["variable_details"]
+    field_location: "templateVariable field in variable_details.csv"
+    status: "active"
+    values: ["Yes", "No", null, "", "<template_name>"]
+  
+  tagged_missing_data:
+    description: "Integration with haven::tagged_na() for survey missing data patterns."
+    affects_schemas: ["variables", "variable_details"]
+    field_location: "recEnd, recStart fields"
+    status: "active"
+    standard_codes: ["NA::a", "NA::b", "NA::c", "NA::d"]
+
+# ============================================================================
+# DATABASE-SPECIFIC EXTENSIONS - Project-specific metadata
+# ============================================================================
+
+database_specific_extensions:
+  description: "Framework for database/project-specific schema extensions and validation rules."
+  versioning_strategy: |
+    Database-specific extensions use independent versioning from core schemas:
+    - Core schemas (variables.yaml, variable_details.yaml): version 1.0.0
+    - Database extensions (e.g., variables_cchs.yaml): version 2.2.0+
+    - Registry coordination: metadata_registry.yaml version 1.0.0
+    
+  extension_mechanism:
+    description: "Projects can create database-specific extensions as separate YAML files."
+    note: "Implementation patterns may vary based on project needs and validation tool requirements."
+      
+  supported_databases:
+    cchs:
+      description: "Canadian Community Health Survey extensions"
+      files: ["variables_cchs_example.yaml", "variable_details_cchs_example.yaml"]
+      version: "2.2.0"
+      status: "production"
+
+# Note: Usage guidance and implementation examples are documented separately
+# in the metadata schema documentation and individual schema files.
+

--- a/inst/metadata/schemas/chms/chms_database_config.yaml
+++ b/inst/metadata/schemas/chms/chms_database_config.yaml
@@ -1,0 +1,130 @@
+schema_version: "1.0.0"
+schema_date: "2025-10-18"
+description: "CHMS database configuration for chmsflow package - following recodeflow conventions"
+
+# ============================================================================
+# CHMS DATABASE CONFIGURATION
+# ============================================================================
+# Note: variableStart formats, range notation, and tagged_na are RECODEFLOW
+# conventions, not CHMS-specific. These patterns support rec_with_table() and
+# other recodeflow functions across all harmonization projects (CCHS, CHMS, etc.)
+#
+# CHMS-specific elements are: cycle naming, valid cycle lists, and cycle-specific
+# variable naming patterns observed in CHMS data.
+# ============================================================================
+
+database_config:
+  name: "CHMS"
+  database_description: "Canadian Health Measures Survey database configuration following recodeflow conventions"
+
+  # Database naming patterns for CHMS
+  naming_patterns:
+    primary_pattern: "cycle(\\d+)"
+    description: "Primary regex pattern to identify CHMS cycles"
+    examples: ["cycle1", "cycle2", "cycle3", "cycle4", "cycle5", "cycle6"]
+
+    medication_pattern: "cycle(\\d+)_meds"
+    description: "Medication-specific cycles"
+    examples: ["cycle1_meds", "cycle2_meds", "cycle3_meds", "cycle4_meds", "cycle5_meds", "cycle6_meds"]
+
+  # Cycle validation rules
+  cycle_validation:
+    min_cycle: 1
+    max_cycle: 10
+    description: "Valid cycle range for CHMS surveys"
+    rationale: "CHMS began with Cycle 1 (2007-2009), currently at Cycle 6"
+    valid_cycles:
+      - "cycle1"
+      - "cycle2"
+      - "cycle3"
+      - "cycle4"
+      - "cycle5"
+      - "cycle6"
+      - "cycle7"
+      - "cycle1_meds"
+      - "cycle2_meds"
+      - "cycle3_meds"
+      - "cycle4_meds"
+      - "cycle5_meds"
+      - "cycle6_meds"
+
+  # Database type hierarchy (ordered by preference)
+  type_hierarchy:
+    description: "Database types in order of preference (highest to lowest priority)"
+    levels:
+      1:
+        patterns: ["^cycle\\d+$"]
+        description: "Main survey cycles (highest priority)"
+        examples: ["cycle1", "cycle2", "cycle3", "cycle4", "cycle5", "cycle6"]
+        rationale: "Main cycles have comprehensive health measures data"
+
+      2:
+        patterns: ["_meds$"]
+        description: "Medication-specific data"
+        examples: ["cycle1_meds", "cycle2_meds", "cycle3_meds"]
+        rationale: "Medication data provides pharmaceutical usage information"
+
+  # Exclusion patterns
+  exclusion_rules:
+    description: "Database patterns to exclude from selection"
+    patterns:
+      - pattern: "_test"
+        description: "Test cycles"
+        rationale: "Test cycles should not be used in production"
+        case_sensitive: false
+
+      - pattern: "_draft"
+        description: "Draft cycles"
+        rationale: "Draft cycles are not finalized"
+        case_sensitive: false
+
+  # Selection strategy
+  selection_strategy:
+    description: "Algorithm for selecting optimal database from available options"
+
+    step1:
+      name: "exclusion_filtering"
+      description: "Remove databases matching exclusion patterns"
+
+    step2:
+      name: "type_hierarchy_filtering"
+      description: "Select databases matching highest priority type available"
+      behavior: "select_all_matching_highest_priority"
+
+    step3:
+      name: "cycle_based_selection"
+      description: "Within selected type, choose most recent cycle"
+      behavior: "select_max_cycle_number"
+
+# ============================================================================
+# CHMS-SPECIFIC OBSERVATIONS
+# ============================================================================
+# Note: variableStart formats and parsing strategies are recodeflow conventions
+# documented in variables.yaml and variable_details.yaml
+# This section documents CHMS-specific naming patterns observed in the data
+# ============================================================================
+
+chms_observations:
+  description: "CHMS-specific patterns observed in variable naming across cycles"
+
+  cycle1_naming_differences:
+    description: "Cycle 1 (2007-2009) often used different variable names than later cycles"
+    note: "This is a CHMS data characteristic, not a recodeflow convention"
+    examples:
+      - variable: "alc_015"
+        cycle1_name: "amsdmva1"
+        cycles_2_6_name: "ammdmva1"
+        metadata_format: "cycle1::amsdmva1, [ammdmva1]"
+
+      - variable: "gen_015"
+        cycle1_name: "gen_15"
+        cycles_2_plus_name: "gen_025"
+        metadata_format: "cycle1::gen_15, [gen_025]"
+
+    rationale: |
+      Early CHMS cycles used different variable naming conventions.
+      This is handled in metadata using recodeflow's mixed format:
+        database::exception, [default]
+
+      Where cycle1 gets the specific name, and other cycles use the default.
+

--- a/inst/metadata/schemas/chms/variable_details.yaml
+++ b/inst/metadata/schemas/chms/variable_details.yaml
@@ -1,0 +1,323 @@
+schema_version: "1.0.0"
+schema_date: "2025-06-22"
+description: "Variable details schema for recodeflow - defines transformation rules and recoding specifications for harmonizing data across multiple sources."
+registry_file: "metadata_registry.yaml"
+
+# Note: Shared specifications (CSV format, tier system, validation patterns, etc.)
+# are defined in metadata_registry.yaml to maintain DRY principles
+
+variable_details_schema:
+  title: "Variable details configuration"
+  description: "Defines value-level transformations, recoding logic, and categorical mappings for data harmonization projects."
+  
+  id_column_name: "dummyVariable"
+  
+  # Column order based on cchsflow production + recodeflow extensions
+  expected_column_order:
+    # Core fields (positions 1-16) - cchsflow production compatibility
+    - "variable"
+    - "dummyVariable"
+    - "typeEnd"
+    - "databaseStart"
+    - "variableStart"
+    - "typeStart"
+    - "recEnd"
+    - "numValidCat"
+    - "catLabel"
+    - "catLabelLong"
+    - "units"
+    - "recStart"
+    - "catStartLabel"
+    - "variableStartShortLabel"
+    - "variableStartLabel"
+    - "notes"
+    # Extension fields (positions 17+)
+    - "templateVariable"
+    # Versioning fields (far right)
+    - "version"
+    - "lastUpdated"
+    - "status"
+    - "reviewNotes"
+
+  # Field definitions organized by tier
+  fields:
+    # ============================================================================
+    # CORE FIELDS - Essential for any recodeflow project
+    # ============================================================================
+    
+    - name: "variable"
+      title: "Variable name"
+      description: "Name of the harmonized variable being created."
+      type: "string"
+      tier: "core"
+      constraints:
+        pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
+        foreign_key: "variables.csv:variable"
+      notes: |
+        This should match a variable name defined in your variables.csv file.
+        Use descriptive names that clearly indicate what the variable represents.
+        
+    - name: "dummyVariable"
+      title: "Statistical dummy variable"
+      description: "Dummy variable names for statistical analyses."
+      type: "string"
+      tier: "core"
+      constraints:
+        pattern_reference: "See metadata_registry.yaml dummy_variable_patterns for naming guidelines"
+      notes: |
+        Statistical dummy variables for regression and analysis purposes.
+        Only used for categorical variables. Not intended as unique row identifiers.
+        
+        Recommended patterns for categorical variables:
+        - variable_category (e.g., age_18_24, smoking_current)
+        - 'N/A' for continuous variables
+        
+        For complete patterns and examples, see metadata_registry.yaml dummy_variable_patterns.
+        
+    - name: "typeEnd"
+      title: "Target data type"
+      description: "Type of the variable after harmonization."
+      type: "string"
+      tier: "core"
+      constraints:
+        enum: ["cat", "cont"]
+      notes: |
+        - "cat" for categorical variables (factors with discrete levels)
+        - "cont" for continuous variables (numeric measurements)
+        
+    - name: "databaseStart"
+      title: "Source database"
+      description: "Name of the original database or data source."
+      type: "string"
+      tier: "core"
+      notes: |
+        Identifies which database this transformation rule applies to.
+        Examples: "cchs2017_p", "rai_hc_2019", "custom_survey_2024"
+        
+    - name: "variableStart"
+      title: "Source variable name"
+      description: "Name of the original variable being transformed."
+      type: "string"
+      tier: "core"
+      constraints:
+        pattern_reference: "See metadata_registry.yaml transformation_patterns for validation rules"
+      notes: |
+        Specifies how to find the source data for transformation.
+        Uses same transformation patterns as variables.yaml variableStart field.
+        
+        Supports multiple patterns (case-insensitive):
+        - Simple reference: [HEIGHT] or [height]
+        - Database-specific: cchs2017_p::HWT_2 or cchs2017_p::hwt_2
+        - Derived variables: DerivedVar::[HEIGHT_CM, WEIGHT_KG]
+        - Multiple sources: cchs2017_p::VAR1, cchs2019_p::VAR2
+        - Complex mixed: cchs2001_p::RACA_6A, cchs2003_p::RACC_6A, [ADL_01]
+        
+        For complete validation patterns, see metadata_registry.yaml transformation_patterns.
+        
+    - name: "typeStart"
+      title: "Source data type"
+      description: "Type of the variable in its original form."
+      type: "string"
+      tier: "core"
+      constraints:
+        enum: ["cat", "cont", "N/A"]
+      notes: |
+        Helps understand the transformation being performed.
+        Use "N/A" for derived variables or when type doesn't apply.
+        
+    - name: "recEnd"
+      title: "Target value"
+      description: "The harmonized value after transformation."
+      type: "string"
+      tier: "core"
+      constraints:
+        pattern: "^([0-9]+|[0-9]+\\.[0-9]+|NA::[ab]|Func::[a-zA-Z_][a-zA-Z0-9_]*|copy)$"
+      notes: |
+        Defines what value this rule produces in the harmonized dataset.
+        Common patterns:
+        - Categorical codes: "1", "2", "3" (integers only)
+        - Decimal values: "1.5", "2.75"
+        - Missing data: "NA::a", "NA::b"
+        - Functions: "Func::bmi_calculation"
+        - Copy original: "copy"
+        
+    - name: "numValidCat"
+      title: "Number of valid categories"
+      description: "Total count of valid (non-missing) categories for categorical variables."
+      type: "string"
+      tier: "core"
+      constraints:
+        pattern: "^([0-9]+|N/A)$"
+      notes: |
+        For categorical variables, specify the total number of meaningful categories.
+        Use "N/A" for continuous variables or when not applicable.
+        
+    - name: "catLabel"
+      title: "Category label"
+      description: "Short, display-friendly label for this category."
+      type: "string"
+      tier: "core"
+      notes: |
+        Brief labels suitable for charts, tables, and user interfaces.
+        Examples: "Male", "High", "18-24 years"
+        
+    - name: "catLabelLong"
+      title: "Detailed category label"
+      description: "Comprehensive description for documentation and codebooks."
+      type: "string"
+      tier: "core"
+      notes: |
+        Full descriptive labels for complete documentation.
+        Examples: "Body mass index 25.0-29.9 (overweight)", "Valid skip due to survey logic"
+        
+    - name: "units"
+      title: "Measurement units"
+      description: "Units of measurement for the variable."
+      type: "string"
+      tier: "core"
+      notes: |
+        Specify units for continuous variables to ensure proper interpretation.
+        Examples: "kg", "years", "cm", "minutes/day", "score (0-100)"
+        Leave blank for categorical variables.
+        
+    - name: "recStart"
+      title: "Source value or range"
+      description: "Original value or condition that triggers this transformation."
+      type: "string"
+      tier: "core"
+      constraints:
+        pattern_reference: "See metadata_registry.yaml interval_notation for validation rules"
+      notes: |
+        Defines what source data matches this transformation rule.
+        Enhanced interval notation based on real-world validation with 3,577 records.
+        
+        Supports comprehensive patterns:
+        - Single values: "1", "male", "english"
+        - Closed intervals: "[18.5,24.9]" (includes endpoints)
+        - Open intervals: "(0,18.5)" (excludes endpoints)
+        - Half-open: "[25,30)", "(18.5,25]"
+        - Complex decimals: "[-0.359,1]", "[0.0487,0.1846)"
+        - Missing data: "NA::a", "NA::b"
+        - Default case: "else"
+        - **Derived variables**: "N/A" (for variables computed from other variables)
+        
+        **Usage Guidelines for N/A:**
+        - Function-based derivations: Variables with recEnd="Func::function_name" should have recStart="N/A"
+        - Non-function derivations: Computed variables without original CCHS forms should have recStart="N/A"
+        
+    - name: "catStartLabel"
+      title: "Source category label"
+      description: "Label describing the original category being transformed."
+      type: "string"
+      tier: "core"
+      notes: |
+        Documents what the source category represents in the original data.
+        Helpful for understanding transformations and maintaining documentation.
+        
+    - name: "variableStartShortLabel"
+      title: "Source variable short label"
+      description: "Brief label for the source variable."
+      type: "string"
+      tier: "core"
+      notes: |
+        Abbreviated description of the source variable for compact displays.
+        
+    - name: "variableStartLabel"
+      title: "Source variable label"
+      description: "Full descriptive label of the source variable."
+      type: "string"
+      tier: "core"
+      notes: |
+        Complete description of what the source variable measures or represents.
+        Should match the official documentation from the source database.
+        
+    - name: "notes"
+      title: "Transformation notes"
+      description: "Additional comments or documentation for this transformation rule."
+      type: "string"
+      tier: "core"
+      notes: |
+        Use for any special considerations, assumptions, or explanations needed
+        to understand or maintain this transformation rule.
+
+    # ============================================================================
+    # EXTENSION FIELDS - Enhanced functionality
+    # ============================================================================
+    
+    - name: "templateVariable"
+      title: "Template system indicator"
+      description: "Enables reusable transformation patterns to avoid duplication."
+      type: "string"
+      tier: "extension"
+      constraints:
+        enum: ["Yes", "No", null, ""]
+        usage_reference: "See metadata_registry.yaml extension_registry for implementation details"
+      default_value: "No"
+      notes: |
+        Reduces duplication for intended purposes:
+        - 8 variables × 132 categories = 1,056 rows reduced to 138 rows (87% reduction)
+        
+        Values:
+        - "Yes": This row defines a reusable template
+        - "No": Normal variable (not using templates)
+        - Template name: This variable extends the named template
+        
+        For complete usage guidance and examples, see metadata_registry.yaml extension_registry.
+
+    # ============================================================================
+    # VERSIONING FIELDS - Professional project management
+    # ============================================================================
+    
+    - name: "version"
+      title: "Version number"
+      description: "Semantic version of this variable detail definition."
+      type: "string"
+      tier: "versioning"
+      constraints:
+        pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+      notes: |
+        Track changes to transformation rules using semantic versioning (e.g., 1.0.0).
+        Increment for changes: major.minor.patch
+        
+    - name: "lastUpdated"
+      title: "Last updated"
+      description: "Date when this transformation rule was last modified."
+      type: "string"
+      tier: "versioning"
+      format: "date"
+      constraints:
+        pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      notes: |
+        Use ISO date format: YYYY-MM-DD
+        Helps track when changes were made for collaboration and maintenance.
+        
+    - name: "status"
+      title: "Variable status"
+      description: "Current lifecycle status of this variable."
+      type: "string"
+      tier: "versioning"
+      constraints:
+        enum: ["development", "active", "deprecated", "discontinued", "not_harmonizable", "pending_review"]
+      notes: |
+        Track the variable lifecycle:
+        - "development": Still being developed or tested
+        - "active": Ready for production use
+        - "deprecated": Still available but use discouraged, will be removed in future version
+        - "discontinued": No longer supported, removed from active use
+        - "not_harmonizable": Cannot be harmonized (document why in reviewNotes)
+        - "pending_review": Needs review before finalization
+        
+    - name: "reviewNotes"
+      title: "Review notes"
+      description: "Notes about harmonization decisions and review outcomes."
+      type: "string"
+      tier: "versioning"
+      notes: |
+        Document decisions, rationale, and any issues discovered during review.
+        Useful for team collaboration and future reference.
+
+  # Configuration options (schema-specific)
+  allow_additional_columns: true
+  extension_schema: null
+  
+  # Note: Missing data handling, validation modes, and extensions are defined in metadata_registry.yaml

--- a/inst/metadata/schemas/chms/variables.yaml
+++ b/inst/metadata/schemas/chms/variables.yaml
@@ -1,0 +1,227 @@
+schema_version: "1.0.0"
+schema_date: "2025-06-22"
+description: "Variables schema for recodeflow - defines structure and metadata for variables.csv files used in data harmonization projects."
+registry_file: "metadata_registry.yaml"
+
+# Note: Shared specifications (CSV format, tier system, validation patterns, etc.)
+# are defined in metadata_registry.yaml to maintain DRY principles
+
+variables_schema:
+  title: "Variables configuration"
+  description: "Defines master variable attributes, types, labels, and specifications for harmonization projects."
+  
+  id_column_name: "variable"
+  
+  # Column order - core fields first, then optional, then versioning
+  expected_column_order:
+    # Core fields - essential for any project
+    - "variable"
+    - "label"
+    - "labelLong"
+    - "variableType"
+    - "databaseStart"
+    - "variableStart"
+    # Optional fields - enhanced documentation
+    - "subject"
+    - "section"
+    - "units"
+    - "notes"
+    - "description"
+    # Extension fields - enhanced functionality
+      # Currently no extension fields for variables
+    # Versioning fields - professional workflows
+    - "version"
+    - "lastUpdated"
+    - "status"
+    - "reviewNotes"
+
+  # Field definitions organized by tier
+  fields:
+    # ============================================================================
+    # CORE FIELDS - Essential for any recodeflow project
+    # ============================================================================
+    
+    - name: "variable"
+      title: "Variable name"
+      description: "Unique name of the harmonized variable you are creating."
+      type: "string"
+      tier: "core"
+      constraints:
+        unique: true
+        pattern: "^[a-zA-Z_][a-zA-Z0-9_]*$"
+      notes: |
+        Choose descriptive names that clearly indicate what the variable represents.
+        Follow R naming conventions: start with letter/underscore, use letters/numbers/underscores only.
+        Examples: age_group, bmi_category, smoking_status
+        
+    - name: "label"
+      title: "Short label"
+      description: "Brief, human-readable label for displays and charts."
+      type: "string"
+      tier: "core"
+      notes: |
+        Keep concise (under 20 characters) for use in charts, tables, and compact displays.
+        Examples: "Age group", "BMI category", "Income level"
+        
+    - name: "labelLong"
+      title: "Long label"
+      description: "Detailed description for documentation and codebooks."
+      type: "string"
+      tier: "core"
+      notes: |
+        Comprehensive description used in data dictionaries and documentation.
+        Include operational definitions and important context.
+        Examples: "Body mass index categories based on WHO classification", 
+                  "Age at time of interview, grouped into 10-year intervals"
+        
+    - name: "variableType"
+      title: "Variable type"
+      description: "Whether the variable represents categories or continuous measurements."
+      type: "string"
+      tier: "core"
+      constraints:
+        enum: ["Categorical", "Continuous"]
+      notes: |
+        Determines how rec_with_table() processes the variable:
+        - "Categorical": Discrete categories or groups (factors with levels)
+        - "Continuous": Numeric measurements or counts
+        
+    - name: "databaseStart"
+      title: "Source database(s)"
+      description: "Name(s) of the original database(s) containing this variable's source data."
+      type: "string"
+      tier: "core"
+      notes: |
+        Identifies which databases contain the source data for this harmonized variable.
+        Examples: 
+        - Single database: "cchs2017_p", "rai_hc_2019"
+        - Multiple databases: "cchs2017_p, cchs2019_p, cchs2021_p"
+        
+    - name: "variableStart"
+      title: "Source variable specification"
+      description: "How to find and combine source data to create this harmonized variable."
+      type: "string"
+      tier: "core"
+      constraints:
+        pattern_reference: "See metadata_registry.yaml transformation_patterns for validation rules"
+      notes: |
+        Specifies the transformation pattern for creating this variable.
+        Critical for data harmonization workflows - tells rec_with_table() how to find and transform source data.
+        
+        Supports multiple patterns (case-insensitive):
+        - Simple reference: [HEIGHT] or [height]
+        - Database-specific: cchs2017_p::HWT_2 or cchs2017_p::hwt_2
+        - Derived variables: DerivedVar::[HEIGHT_CM, WEIGHT_KG]
+        - Multiple sources: cchs2017_p::VAR1, cchs2019_p::VAR2
+        - Complex mixed: cchs2001_p::RACA_6A, cchs2003_p::RACC_6A, [ADL_01]
+        
+        For complete validation patterns and examples, see metadata_registry.yaml transformation_patterns.
+
+    # ============================================================================
+    # OPTIONAL FIELDS - Enhanced documentation and organization
+    # ============================================================================
+    
+    - name: "subject"
+      title: "Subject area"
+      description: "Thematic area or domain this variable belongs to."
+      type: "string"
+      tier: "optional"
+      notes: |
+        Groups variables by topic for better organization.
+        Examples: "Demographics", "Health behaviors", "Social determinants", "Physical measures"
+        
+    - name: "section"
+      title: "Survey section"
+      description: "Specific section or module where this variable originates."
+      type: "string"
+      tier: "optional"
+      notes: |
+        Identifies the source questionnaire section or data collection module.
+        Examples: "Core demographics", "Health status", "Physical activity module"
+        
+    - name: "units"
+      title: "Measurement units"
+      description: "Units of measurement for continuous variables."
+      type: "string"
+      tier: "optional"
+      notes: |
+        Essential for continuous variables to ensure proper interpretation.
+        Examples: "kg", "years", "cm", "minutes/day", "score (0-100)"
+        Leave blank for categorical variables.
+        
+    - name: "notes"
+      title: "General notes"
+      description: "Additional comments or important information about this variable."
+      type: "string"
+      tier: "optional"
+      notes: |
+        Use for any special considerations, limitations, or usage notes.
+        Examples: methodology notes, data quality issues, interpretation guidance.
+        
+    - name: "description"
+      title: "Detailed description"
+      description: "Comprehensive definition including methodology and operational details."
+      type: "string"
+      tier: "optional"
+      notes: |
+        Full technical description including how the variable is constructed,
+        any assumptions made, and methodological considerations.
+
+    # ============================================================================
+    # VERSIONING FIELDS - Best-practice project management
+    # ============================================================================
+    
+    - name: "version"
+      title: "Version number"
+      description: "Semantic version of this variable definition."
+      type: "string"
+      tier: "versioning"
+      constraints:
+        pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+      notes: |
+        Track changes using semantic versioning (e.g., 1.0.0).
+        Increment for changes: major.minor.patch
+        
+    - name: "lastUpdated"
+      title: "Last updated"
+      description: "Date when this variable definition was last modified."
+      type: "string"
+      tier: "versioning"
+      format: "date"
+      constraints:
+        pattern: "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+      notes: |
+        Use ISO date format: YYYY-MM-DD
+        Helps track when changes were made for collaboration and maintenance.
+        
+    - name: "status"
+      title: "Variable status"
+      description: "Current lifecycle status of this variable."
+      type: "string"
+      tier: "versioning"
+      constraints:
+        enum: ["development", "active", "deprecated", "discontinued", "not_harmonizable", "pending_review"]
+      notes: |
+        Track the variable lifecycle:
+        - "development": Still being developed or tested
+        - "active": Ready for production use
+        - "deprecated": Still available but use discouraged, will be removed in future version
+        - "discontinued": No longer supported, removed from active use
+        - "not_harmonizable": Cannot be harmonized (document why in reviewNotes)
+        - "pending_review": Needs review before finalization
+        
+    - name: "reviewNotes"
+      title: "Review notes"
+      description: "Notes about harmonization decisions and review outcomes."
+      type: "string"
+      tier: "versioning"
+      notes: |
+        Document decisions, rationale, and any issues discovered during review.
+        Useful for team collaboration and future reference.
+
+  # Configuration options (schema-specific)
+  allow_additional_columns: true
+  extension_schema: null
+
+  # Note: Missing data handling, validation modes, and extensions are defined in metadata_registry.yaml
+


### PR DESCRIPTION
Schema documentation for recodeflow metadata structure applied to CHMS.

These are based on newly-develop metadata documentation within the current recodeflow and cchsflow refactoring. They may still change before they are finalized. They are independently useful for understanding CHMS metadata conventions and serve as reference documentation for anyone working with variables.csv and variable-details.csv files. They are helpful for validation the csv files, for making mock data and other uses.

Schema files (inst/metadata/schemas/chms/):
- variables.yaml: Field definitions for variables.csv (variable, label, variableType, databaseStart, variableStart, etc.)
- variable_details.yaml: Field definitions for variable-details.csv (variable, recodes, categories, typeStart, typeEnd, etc.)
- chms_database_config.yaml: CHMS-specific database configuration (valid cycles, selection strategies, CHMS observations)

Documentation (inst/metadata/README.md):
- Distinguishes recodeflow conventions vs CHMS-specific patterns
- Explains variableStart format patterns:
  * Bracket format: [varname] for consistent names
  * Cycle-prefixed: cycle1::varname for cycle-specific names
  * Mixed format: cycle1::var1, [var2] (override + default pattern)
  * DerivedVar: DerivedVar::[var1, var2] for calculated variables
- Documents range notation for categorical recodes:
  * Integer ranges: [7,9] includes 7,8,9
  * Continuous ranges: [18.5,25) for BMI categories
  * Special values: 'else' as catch-all
- CHMS observations: Cycle 1 often used different variable names than Cycles 2-6 (handled via mixed format convention)
 