### PR TITLE
Run R-CMD-check on dev pull requests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,9 +2,10 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, dev]
   pull_request:
-    branches: [main, master]
+    branches: [main, master, dev]
+  workflow_dispatch:
 
 name: R-CMD-check
 


### PR DESCRIPTION
## Summary

- Add `dev` to the `R-CMD-check` workflow triggers on `main`
- Allows PRs targeting `dev`, including CRAN-prep PRs #22 and #23, to run the full R CMD check matrix

## Why

GitHub discovers workflow triggers from the default branch. Although `dev` already includes this trigger change, the default-branch workflow still only listens to `main`/`master`, so recent PRs into `dev` did not run `R-CMD-check`.

## Checks

- Workflow-only change; no package code changed